### PR TITLE
feat: update project badge style to match Today's Focus (pomofly-cf9)

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,40 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["src/*"],
+      "@/components/*": ["src/components/*"],
+      "@/hooks/*": ["src/hooks/*"],
+      "@/lib/*": ["src/lib/*"],
+      "@/app/*": ["src/app/*"]
+    },
+    "baseUrl": ".",
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "es6"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -25,7 +25,6 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { Combobox } from './ui/combobox';
-import { cn } from '@/lib/utils';
 import { AIBreakdownModal } from './AIBreakdownModal';
 import { Switch } from '@/components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
-import { MoreHorizontal, Plus, Pencil, Trash2, Star, Calendar, ChevronDown, ChevronRight, Search, ArrowUpAZ, ArrowDownAZ, Filter, CheckCircle, Eye } from 'lucide-react';
+import { MoreHorizontal, Plus, Pencil, Trash2, Star, Calendar, ChevronDown, ChevronRight, Search, ArrowUpAZ, ArrowDownAZ, Filter, CheckCircle, Eye, FolderOpen } from 'lucide-react';
 import TaskTimeTracker from './TaskTimeTracker';
 import TimeTrackingControls from './TimeTrackingControls';
 import BulkActionToolbar from './BulkActionToolbar';
@@ -25,6 +25,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { Combobox } from './ui/combobox';
+import { cn } from '@/lib/utils';
 import { AIBreakdownModal } from './AIBreakdownModal';
 import { Switch } from '@/components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -236,21 +237,14 @@ const TaskList: React.FC<TaskListProps> = React.memo(({ settings }) => {
   // Project Badge Component
   const ProjectBadge = ({ projectId }: { projectId: string }) => {
     const projectName = getProjectName(projectId);
-    const displayName = projectName.length > 8 ? projectName.substring(0, 8) + '...' : projectName;
-    
-    // Debug logging
-    console.log('ProjectBadge Debug:', {
-      projectId,
-      projectName,
-      availableProjects: memoizedProjects.map(p => ({ id: p.id, name: p.name })),
-      foundProject: memoizedProjects.find(p => p.id === projectId)
-    });
-    
+    const displayName = projectName.length > 12 ? projectName.substring(0, 12) + '...' : projectName;
+
     return (
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
-            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-800 max-w-24 overflow-hidden">
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium bg-secondary text-secondary-foreground transition-colors duration-150 hover:bg-secondary/80">
+              <FolderOpen className="w-3 h-3" />
               {displayName}
             </span>
           </TooltipTrigger>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,10 @@
     ],
     "paths": {
       "@/*": ["src/*"],
-      "@/components/*": ["src/components/*"]
+      "@/components/*": ["src/components/*"],
+      "@/hooks/*": ["src/hooks/*"],
+      "@/lib/*": ["src/lib/*"],
+      "@/app/*": ["src/app/*"]
     },
     "baseUrl": "."
   },


### PR DESCRIPTION
## Summary
- Update ProjectBadge in TaskList to use secondary color scheme (`bg-secondary`, `text-secondary-foreground`) matching TodayFocusSection
- Add FolderOpen icon, rounded-md border, and hover effect
- Increase name truncation from 8 to 12 characters
- Remove debug `console.log` statement

## Test plan
- [ ] Verify project badges in task list match Today's Focus section style
- [ ] Verify tooltip still shows full project name on hover
- [ ] Verify badges appear correctly in completed tasks section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Updates**
  * Added a folder icon to project badges.
  * Increased displayed project name length for improved readability.
  * Updated badge styling for better visual consistency.

* **Chores**
  * Removed debug logging output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->