### PR TITLE
feat: add focus option when creating new task (pomofly-139)

### DIFF
--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -188,6 +188,7 @@ const TaskList: React.FC<TaskListProps> = React.memo(({ settings }) => {
   const [newTaskTitle, setNewTaskTitle] = useState('');
   const [estimatedPomodoros, setEstimatedPomodoros] = useState<number | undefined>(undefined);
   const [selectedProjectId, setSelectedProjectId] = useState('');
+  const [newTaskFocus, setNewTaskFocus] = useState(false);
   const [editingTask, setEditingTask] = useState<{ id: string, title: string, estimatedPomodoros?: number, projectId?: string } | null>(null);
   const [editingDeadline, setEditingDeadline] = useState<{ id: string, deadline: string } | null>(null);
   const [showCompleted, setShowCompleted] = useState(false);
@@ -264,19 +265,21 @@ const TaskList: React.FC<TaskListProps> = React.memo(({ settings }) => {
     e.preventDefault();
     if (newTaskTitle.trim() && selectedProjectId) {
       try {
-        await addTask(newTaskTitle, selectedProjectId, estimatedPomodoros);
+        await addTask(newTaskTitle, selectedProjectId, estimatedPomodoros, newTaskFocus);
         event('task_added', {
           project_id: selectedProjectId,
-          estimated_pomodoros: estimatedPomodoros
+          estimated_pomodoros: estimatedPomodoros,
+          focus: newTaskFocus
         });
         setNewTaskTitle('');
         setEstimatedPomodoros(0);
+        setNewTaskFocus(false);
       } catch (error) {
         console.error("Failed to add task:", error);
         event('task_add_error', { error_message: (error as Error).message });
       }
     }
-  }, [addTask, event, estimatedPomodoros, newTaskTitle, selectedProjectId]);
+  }, [addTask, event, estimatedPomodoros, newTaskTitle, selectedProjectId, newTaskFocus]);
 
   const handleUpdateTask = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
@@ -573,6 +576,21 @@ const TaskList: React.FC<TaskListProps> = React.memo(({ settings }) => {
                 />
               </div>
 
+            </div>
+            <div className="flex items-center space-x-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setNewTaskFocus(!newTaskFocus)}
+                className={cn("p-1", newTaskFocus ? "text-yellow-500" : "text-gray-400")}
+                aria-label={newTaskFocus ? "Remove from Today's Focus" : "Add to Today's Focus"}
+              >
+                <Star className="w-4 h-4" fill={newTaskFocus ? "currentColor" : "none"} />
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                {newTaskFocus ? "Added to Today's Focus" : "Add to Today's Focus"}
+              </span>
             </div>
             <div className="flex items-center space-x-2">
               <Button type="submit" className="w-1/2">

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -86,7 +86,7 @@ export function useTasks(projectId?: string) {
     }
   }, [isGuest, projectId]);
 
-  const addTask = useCallback(async (title: string, taskProjectId: string, estimatedPomodoros?: number) => {
+  const addTask = useCallback(async (title: string, taskProjectId: string, estimatedPomodoros?: number, focus?: boolean) => {
     const user = auth.currentUser;
 
     const newTaskData = {
@@ -98,7 +98,7 @@ export function useTasks(projectId?: string) {
       totalTimeSpent: 0,
       createdAt: new Date(),
       estimatedPomodoros,
-      focus: false,
+      focus: focus ?? false,
       deadline: null,
       manualTimeSpent: 0,
       trackingStartedAt: null


### PR DESCRIPTION
## Summary
- Add optional `focus` parameter to `addTask` function in `useTasks` hook
- Add star toggle button to the task creation form in TaskList
- Task focus state resets after successful creation
- Analytics event tracks focus state

## Test plan
- [ ] Verify star toggle appears in add task form
- [ ] Verify clicking star toggles between active/inactive states
- [ ] Verify creating task with star marks it as focused (appears in Today's Focus)
- [ ] Verify star resets after task creation
- [ ] Verify creating task without star still defaults to not focused