### PR TITLE
feat: create new project from task creation selector (pomofly-v4i)

### DIFF
--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -205,7 +205,7 @@ const TaskList: React.FC<TaskListProps> = React.memo(({ settings }) => {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [taskToDelete, setTaskToDelete] = useState<string | null>(null);
 
-  const { projects } = useProjects();
+  const { projects, addProject } = useProjects();
   const {
     tasks,
     loading: tasksLoading,
@@ -228,6 +228,30 @@ const TaskList: React.FC<TaskListProps> = React.memo(({ settings }) => {
 
   // Time tracking hook
   const { activelyTrackedTasks, hasActiveTracking, getElapsedTime, formatTime } = useTimeTracking(memoizedTasks);
+
+  const handleCreateProject = useCallback(async (name: string) => {
+    try {
+      const newProjectId = await addProject(name);
+      if (newProjectId) {
+        setSelectedProjectId(newProjectId);
+        event('project_created_from_task_form', { project_name: name });
+      }
+    } catch (error) {
+      console.error("Failed to create project:", error);
+    }
+  }, [addProject, event]);
+
+  const handleCreateProjectForEdit = useCallback(async (name: string) => {
+    try {
+      const newProjectId = await addProject(name);
+      if (newProjectId) {
+        setEditingTask(prev => prev ? { ...prev, projectId: newProjectId } : prev);
+        event('project_created_from_task_form', { project_name: name });
+      }
+    } catch (error) {
+      console.error("Failed to create project:", error);
+    }
+  }, [addProject, event]);
 
   // Helper function to get project name by ID
   const getProjectName = useCallback((projectId: string) => {
@@ -573,6 +597,7 @@ const TaskList: React.FC<TaskListProps> = React.memo(({ settings }) => {
                   value={selectedProjectId}
                   onChange={(value) => setSelectedProjectId(value)}
                   placeholder="Select a project"
+                  onCreateNew={handleCreateProject}
                 />
               </div>
 
@@ -728,6 +753,7 @@ const TaskList: React.FC<TaskListProps> = React.memo(({ settings }) => {
                       value={editingTask.projectId || ''}
                       onChange={(value) => setEditingTask({ ...editingTask, projectId: value })}
                       placeholder="Select a project"
+                      onCreateNew={handleCreateProjectForEdit}
                     />
                     <Button type="submit" size="sm" variant="outline">Save</Button>
                     <Button type="button" size="sm" variant="ghost" onClick={() => setEditingTask(null)}>Cancel</Button>

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Check, ChevronsUpDown } from "lucide-react";
+import { Check, ChevronsUpDown, Plus } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -27,6 +27,7 @@ interface ComboboxProps {
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
+  onCreateNew?: (name: string) => void;
 }
 
 export const Combobox: React.FC<ComboboxProps> = ({
@@ -34,9 +35,15 @@ export const Combobox: React.FC<ComboboxProps> = ({
   value,
   onChange,
   placeholder = "Select an option...",
+  onCreateNew,
 }) => {
   const [open, setOpen] = React.useState(false);
   const [searchValue, setSearchValue] = React.useState("");
+
+  const hasExactMatch = options.some(
+    (option) => option.label.toLowerCase() === searchValue.trim().toLowerCase()
+  );
+  const showCreateOption = onCreateNew && searchValue.trim() && !hasExactMatch;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -61,7 +68,7 @@ export const Combobox: React.FC<ComboboxProps> = ({
             onValueChange={setSearchValue}
           />
           <CommandList>
-            <CommandEmpty>No options found.</CommandEmpty>
+            {!showCreateOption && <CommandEmpty>No options found.</CommandEmpty>}
             <CommandGroup>
               {options.map((option) => (
                 <CommandItem
@@ -82,6 +89,19 @@ export const Combobox: React.FC<ComboboxProps> = ({
                   {option.label}
                 </CommandItem>
               ))}
+              {showCreateOption && (
+                <CommandItem
+                  value={`__create__${searchValue.trim()}`}
+                  onSelect={() => {
+                    onCreateNew(searchValue.trim());
+                    setOpen(false);
+                    setSearchValue("");
+                  }}
+                >
+                  <Plus className="mr-2 h-4 w-4" />
+                  Create &ldquo;{searchValue.trim()}&rdquo;
+                </CommandItem>
+              )}
             </CommandGroup>
           </CommandList>
         </Command>


### PR DESCRIPTION
## Summary
- Add `onCreateNew` prop to Combobox component (optional, backward compatible)
- Show "Create [search text]" option when no exact match found and `onCreateNew` is provided
- Wire up inline project creation in both add task and edit task forms
- Auto-select newly created project after creation

## Test plan
- [ ] Verify typing a non-existing project name shows "Create [name]" option
- [ ] Verify clicking "Create" creates the project and auto-selects it
- [ ] Verify it works in both add task form and edit task form
- [ ] Verify existing Combobox usage without `onCreateNew` still works normally
- [ ] Verify exact match of existing project name does NOT show create option